### PR TITLE
remove pygments from load package

### DIFF
--- a/src/frontend/src/worker.ts
+++ b/src/frontend/src/worker.ts
@@ -70,7 +70,7 @@ async function getPyodide(): Promise<PyodideInterface> {
     })
     console.log('Pyodide version', pyodide.version)
     setupStreams(pyodide)
-    await pyodide.loadPackage(['micropip', 'pygments'])
+    await pyodide.loadPackage(['micropip'])
 
     const pathlib = pyodide.pyimport('pathlib')
     pathlib.Path('run.py').write_text(pythonCode)


### PR DESCRIPTION
cc @hoodmane

If you run the code on this preview (click "View deployment" below, then "Run"), you'll see:

```
raceback (most recent call last):
  File "/home/pyodide/run.py", line 77, in run_code
    spec.loader.exec_module(module)
  File "/home/pyodide/main.py", line 5, in <module>
    import logfire
  File "/lib/python3.12/site-packages/logfire/__init__.py", line 11, in <module>
    from ._internal.config import AdvancedOptions, CodeSource, ConsoleOptions, MetricsOptions, PydanticPlugin, configure
  File "/lib/python3.12/site-packages/logfire/_internal/config.py", line 63, in <module>
    from .config_params import ParamManager, PydanticPluginRecordValues
  File "/lib/python3.12/site-packages/logfire/_internal/config_params.py", line 17, in <module>
    from .exporters.console import ConsoleColorsValues
  File "/lib/python3.12/site-packages/logfire/_internal/exporters/console.py", line 21, in <module>
    from rich.syntax import Syntax
  File "/lib/python3.12/site-packages/rich/syntax.py", line 22, in <module>
    from pygments.lexer import Lexer
ModuleNotFoundError: No module named 'pygments'
```

but if you try [this](https://86a54591-pydantic-run-previews.pydantic.workers.dev/store/fa2e44fd735d8df5) code, specifically:

```
# /// script
# dependencies = ["rich"]
# ///

from rich.console import Console

console = Console()
console.print('[red]hello[/red]')
```

It runs fine.

But you can see [here](https://github.com/pydantic/logfire/blob/a9ffc3581e7252f0497234537617b5c7866d44c4/pyproject.toml#L52) that logfire has rich as a plain dependency.

This is where we're installing packages:

https://github.com/pydantic/pydantic.run/blob/770264bdd4c29fe6daeeb9e5453874727463eb13/src/frontend/src/run.py#L57