### PR TITLE
Upgrade pyodide to 0.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1793,6 +1793,10 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/backend": {
+      "resolved": "src/backend",
+      "link": true
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1917,10 +1921,6 @@
         "debug": "^4.3.1",
         "tslib": "^2.2.0"
       }
-    },
-    "node_modules/backend": {
-      "resolved": "src/backend",
-      "link": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3222,10 +3222,10 @@
       }
     },
     "node_modules/pyodide": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.27.2.tgz",
-      "integrity": "sha512-sfA2kiUuQVRpWI4BYnU3sX5PaTTt/xrcVEmRzRcId8DzZXGGtPgCBC0gCqjUTUYSa8ofPaSjXmzESc86yvvCHg==",
-      "license": "Apache-2.0",
+      "version": "0.28.3",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.28.3.tgz",
+      "integrity": "sha512-rtCsyTU55oNGpLzSVuAd55ZvruJDEX8o6keSdWKN9jPeBVSNlynaKFG7eRqkiIgU7i2M6HEgYtm0atCEQX3u4A==",
+      "license": "MPL-2.0",
       "dependencies": {
         "ws": "^8.5.0"
       },
@@ -4790,7 +4790,7 @@
         "@eslint/js": "^9.18.0",
         "ansi-to-html": "^0.7.2",
         "monaco-editor": "^0.52.2",
-        "pyodide": "^0.27.2",
+        "pyodide": "^0.28.3",
         "sass-embedded": "^1.83.4",
         "solid-js": "^1.9.4",
         "typescript-eslint": "^8.20.0",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -13,7 +13,7 @@
     "@eslint/js": "^9.18.0",
     "ansi-to-html": "^0.7.2",
     "monaco-editor": "^0.52.2",
-    "pyodide": "^0.27.2",
+    "pyodide": "^0.28.3",
     "sass-embedded": "^1.83.4",
     "solid-js": "^1.9.4",
     "typescript-eslint": "^8.20.0",

--- a/src/frontend/src/worker.ts
+++ b/src/frontend/src/worker.ts
@@ -91,15 +91,11 @@ interface PyodideEnv {
   preparePyEnv: { prepare_env: (files: any) => Promise<PrepareSuccess | PrepareError> }
 }
 
-// see https://github.com/pyodide/micropip/issues/201
-const micropipV09 =
-  'https://files.pythonhosted.org/packages/27/6d/195810e3e73e5f351dc6082cada41bb4d5b0746a6804155ba6bae4304612/micropip-0.9.0-py3-none-any.whl'
-
 // we rerun this on every invocation to avoid issues with conflicting packages
 async function getPyodideEnv(): Promise<PyodideEnv> {
   const pyodide = await loadPyodide({
     indexURL: `https://cdn.jsdelivr.net/pyodide/v${pyodideVersion}/full/`,
-    packages: [micropipV09],
+    packages: ['micropip'],
   })
   const sys = pyodide.pyimport('sys')
   const pv = sys.version_info


### PR DESCRIPTION
This has Python 3.13, and doesn't need the micropip workaround any more.
